### PR TITLE
use `find` to match mmcblk partitions

### DIFF
--- a/files/init
+++ b/files/init
@@ -162,7 +162,7 @@ mkdir /dev/targetSD
 hostController="$(readlink /dev/block/by-name/super |sed -E 's;/dev/(.*)p[0-9]*;\1;g')"
 sdcard=""
 for k in $(seq 1 15);do
-    for i in /dev/mmcblk*p1;do
+    for i in $(find /dev -name 'mmcblk*p1');do
         if echo "$i" |grep -v -q "$hostController";then
             sdcard="$i"
         fi


### PR DESCRIPTION
On some devices `mmcblk*` do not show up until a few seconds later. With
the shell pattern matcher, if `mmcblk*p1` matches nothing, it will just
return `mmcblk*p1` unchanged, which causes issues with our script.

Use `find` instead.